### PR TITLE
Change order of affiliates API URL patterns.

### DIFF
--- a/lms/djangoapps/affiliates/api/urls.py
+++ b/lms/djangoapps/affiliates/api/urls.py
@@ -13,8 +13,8 @@ from affiliates.api.views import (
 urlpatterns = patterns(
     '',
     url(r'^$', AffiliateEntityViewSet.as_view(), name='create'),
-    url(r'^(?P<affiliate_slug>[^/]*)$', AffiliateEntityDetailsViewSet.as_view(), name='details'),
-    url(r'^(?P<affiliate_slug>[^/]*)/membership$', AffiliateEntityMembershipViewSet.as_view(), name='membership'),
     url(r'^impersonate$', ImpersonateView.as_view(), name='impersonate'),
-    url(r'^data-exports$', DataExportView.as_view(), name='data-exports')
+    url(r'^data-exports$', DataExportView.as_view(), name='data-exports'),
+    url(r'^(?P<affiliate_slug>[^/]+)$', AffiliateEntityDetailsViewSet.as_view(), name='details'),
+    url(r'^(?P<affiliate_slug>[^/]+)/membership$', AffiliateEntityMembershipViewSet.as_view(), name='membership'),
 )


### PR DESCRIPTION
The previous order was capturing 'impersonate' and 'data-exports'
with the '[^/]*' pattern as well.