### PR TITLE
Fix facilitators check on course creation flow.

### DIFF
--- a/themes/fast-track-theme/lms/templates/dashboard.html
+++ b/themes/fast-track-theme/lms/templates/dashboard.html
@@ -288,6 +288,8 @@ from openedx.core.djangolib.markup import HTML, Text
           }
         }
       });
+
+      return false;
     });
   });
   </script>


### PR DESCRIPTION
Part of KF-877
It used to redirect the user to the creation form if the click
Cancel on the prompt. Returning `false` fixes this and now the
user will stay on the courses list dashboard page.